### PR TITLE
IdentityHashSet based guard

### DIFF
--- a/src/main/java/com/javaetmoi/core/persistence/hibernate/LazyLoadingUtil.java
+++ b/src/main/java/com/javaetmoi/core/persistence/hibernate/LazyLoadingUtil.java
@@ -131,10 +131,12 @@ public class LazyLoadingUtil {
             Hibernate.initialize(entity);
         }
 
-        for (int i = 0, n = classMetadata.getPropertyNames().length; i < n; i++) {
-            String propertyName = classMetadata.getPropertyNames()[i];
-            Type propertyType = classMetadata.getPropertyType(propertyName);
-            Object propertyValue = null;
+        String[] propertyNames = classMetadata.getPropertyNames();
+        Type[] propertyTypes = classMetadata.getPropertyTypes();
+        for (int i = 0, n = propertyNames.length; i < n; i++) {
+            String propertyName = propertyNames[i];
+            Type propertyType = propertyTypes[i];
+            Object propertyValue;
             if (entity instanceof javassist.util.proxy.ProxyObject) {
                 // For javassist proxy, the classMetadata.getPropertyValue(..) method return en
                 // empty collection. So we have to call the property's getter in order to call the


### PR DESCRIPTION
I had severe performance issues due to lazy initialization, probably because of an entity model with some circular references and ~ 1 million entities. So I tried to tune the performance of the lazy loading util. Finally I decided to try to replace the string based guard by an IdentityHashSet. The tests run and I got good performance (just a few seconds compared to up to almost hours before).

I hope you like it ;-)
