### PR TITLE
Fix Hibernate 5.2.0 incompatibilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,20 +78,21 @@
   <properties>
     <!-- Version of third libraries -->
     <!-- * JPA 2 and Hibernate dependencies -->
-    <version.hibernate>5.1.0.Final</version.hibernate>
-    <version.hibernate-javassist>3.18.1-GA</version.hibernate-javassist>
+    <version.hibernate>5.2.0.Final</version.hibernate>
+    <version.hibernate-entitymanager>5.1.0.Final</version.hibernate-entitymanager>
+    <version.hibernate-javassist>3.20.0-GA</version.hibernate-javassist>
     <version.hibernate-jpa-2.1-api>1.0.0.Final</version.hibernate-jpa-2.1-api>
-    <version.logback>1.1.2</version.logback>
+    <version.logback>1.1.7</version.logback>
 
     <!-- * For testing purpose -->
-    <version.junit>4.11</version.junit>
-    <version.spring>4.2.1.RELEASE</version.spring>
-    <version.h2>1.4.177</version.h2>
-    <version.dbunit>2.4.9</version.dbunit>
-    <version.commons-lang3>3.3.2</version.commons-lang3>
-    <version.ehcache>2.6.9</version.ehcache>
-    <version.unitils>3.4.1</version.unitils>
-    <version.mockito>1.9.5</version.mockito>
+    <version.junit>4.12</version.junit>
+    <version.spring>4.3.0.RELEASE</version.spring>
+    <version.h2>1.4.192</version.h2>
+    <version.dbunit>2.5.2</version.dbunit>
+    <version.commons-lang3>3.4</version.commons-lang3>
+    <version.ehcache>2.6.11</version.ehcache>
+    <version.unitils>3.4.2</version.unitils>
+    <version.mockito>1.10.19</version.mockito>
 
     <!-- Version of maven plugins -->
     <version.plugin.maven-eclipse-plugin>2.9</version.plugin.maven-eclipse-plugin>
@@ -125,7 +126,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
-      <version>${version.hibernate}</version>
+      <version>${version.hibernate-entitymanager}</version>
     </dependency>
     <!-- Javassist -->
     <dependency>
@@ -176,7 +177,7 @@
       <version>${version.mockito}</version>
       <scope>test</scope>
     </dependency>
-      <!-- * H2 embbeded database -->
+    <!-- * H2 embbeded database -->
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
@@ -340,9 +341,9 @@
                 </goals>
               </execution>
             </executions>
-              <configuration>
-                  <additionalparam>-Xdoclint:none</additionalparam>
-              </configuration>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
           </plugin>
           <!--GPG Signed Artefacts required by Maven Central -->
           <plugin>

--- a/src/main/java/com/javaetmoi/core/persistence/hibernate/LazyLoadingUtil.java
+++ b/src/main/java/com/javaetmoi/core/persistence/hibernate/LazyLoadingUtil.java
@@ -119,10 +119,17 @@ public class LazyLoadingUtil {
             target = initializer.getImplementation();
         }
 
-        ClassMetadata classMetadata = currentSession.getSessionFactory().getClassMetadata(clazz);
-        if (classMetadata == null) {
+        // TODO Use metamodel instead for future releases...
+        ClassMetadata classMetadata;
+        try {
+            classMetadata = currentSession.getSessionFactory().getClassMetadata(clazz);
+            if (classMetadata == null) {
+                return;
+            }
+        } catch (Exception e) {
             return;
         }
+
 
         if (!Hibernate.isInitialized(entity)) {
             Hibernate.initialize(entity);


### PR DESCRIPTION
getClassMetadata(Class) throws an exception since Hibernate 5.2. My PR catches just this exception and handles it like null values before.

I increased all dependency versions. Spring needs to be 4.3+ for Hibernate 5.2 support . ClassMetadata is deprecated now and will be replaced by the Metamodel. So sooner or later hibernate-hydrate needs to be reworked.

May hibernate-hydrate have the same major and minor version in the future like the hibernate it is compatible to? This would make it easier to find the correct hibernate-hydrate for a hibernate release.