### PR TITLE
Use unwrap() to extract the session and session factory implementor

### DIFF
--- a/src/main/java/com/javaetmoi/core/persistence/hibernate/JpaLazyLoadingUtil.java
+++ b/src/main/java/com/javaetmoi/core/persistence/hibernate/JpaLazyLoadingUtil.java
@@ -53,7 +53,7 @@ public class JpaLazyLoadingUtil {
      *         input parameter. Useful when calling this method in a return statement.
      */
     public static <C extends Collection<E>, E> C deepHydrate(EntityManager currentEntityManager, C entities) {
-        return LazyLoadingUtil.deepHydrate(getSession(currentEntityManager), entities);
+        return LazyLoadingUtil.deepHydrate(currentEntityManager.unwrap(Session.class), entities);
     }
 
     /**
@@ -73,22 +73,6 @@ public class JpaLazyLoadingUtil {
      *         when calling this method in a return statement.
      */
     public static <E> E deepHydrate(EntityManager currentEntityManager, E entity) {
-        return LazyLoadingUtil.deepHydrate(getSession(currentEntityManager), entity);
-    }
-
-   /**
-    * Get Hibernate {@link Session} from {@link EntityManager}.
-    */
-    private static Session getSession(EntityManager currentEntityManager) {
-        // Hibernate 5.2+
-        if (currentEntityManager instanceof Session) {
-            return (Session) currentEntityManager;
-        }
-
-        if (currentEntityManager instanceof org.hibernate.jpa.HibernateEntityManager) {
-            return ((org.hibernate.jpa.HibernateEntityManager) currentEntityManager).getSession();
-        }
-
-        throw new RuntimeException("Only the Hibernate implementation of JPA is currently supported.");
+        return LazyLoadingUtil.deepHydrate(currentEntityManager.unwrap(Session.class), entity);
     }
 }

--- a/src/main/java/com/javaetmoi/core/persistence/hibernate/LazyLoadingUtil.java
+++ b/src/main/java/com/javaetmoi/core/persistence/hibernate/LazyLoadingUtil.java
@@ -81,10 +81,11 @@ public class LazyLoadingUtil {
      *         input parameter. Useful when calling this method in a return statement.
      */
     public static <C extends Collection<E>, E> C deepHydrate(SessionFactory sessionFactory, C entities) {
+        SessionFactoryImplementor sessionFactoryImplementor = sessionFactory.unwrap(SessionFactoryImplementor.class);
         IdentitySet recursiveGuard = new IdentitySet();
         for (Object entity : entities) {
             // TODO markus 2016-06-19: How to determine entity type?
-            deepInflateEntity((SessionFactoryImplementor) sessionFactory, entity, null, recursiveGuard);
+            deepInflateEntity(sessionFactoryImplementor, entity, null, recursiveGuard);
         }
         return entities;
     }
@@ -125,9 +126,10 @@ public class LazyLoadingUtil {
      *         when calling this method in a return statement.
      */
     public static <E> E deepHydrate(SessionFactory sessionFactory, E entity) {
+        SessionFactoryImplementor sessionFactoryImplementor = sessionFactory.unwrap(SessionFactoryImplementor.class);
         IdentitySet recursiveGuard = new IdentitySet();
         // TODO markus 2016-06-19: How to determine entity type?
-        deepInflateEntity((SessionFactoryImplementor) sessionFactory, entity, null, recursiveGuard);
+        deepInflateEntity(sessionFactoryImplementor, entity, null, recursiveGuard);
         return entity;
     }
 


### PR DESCRIPTION
Use the unwrap functionality of the entity manager and entity manager factory interfaces to retrieve underlying implementation. This avoids the usage of deprecated interfaces too.