### PR TITLE
Bump dependencies to Hibernate 5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,17 +82,17 @@
 
     <!-- Version of third libraries -->
     <!-- * Hibernate dependencies -->
-    <version.hibernate>5.4.22.Final</version.hibernate>
+    <version.hibernate>5.6.3.Final</version.hibernate>
 
     <!-- * For testing purpose -->
-    <version.commons-lang3>3.11</version.commons-lang3>
-    <version.dbunit>2.7.0</version.dbunit>
+    <version.commons-lang3>3.12.0</version.commons-lang3>
+    <version.dbunit>2.7.2</version.dbunit>
     <version.ehcache>2.6.11</version.ehcache>
-    <version.h2>1.4.200</version.h2>
-    <version.junit>5.7.0</version.junit>
-    <version.logback>1.2.3</version.logback>
-    <version.mockito>3.5.15</version.mockito>
-    <version.spring>5.2.9.RELEASE</version.spring>
+    <version.h2>2.0.206</version.h2>
+    <version.junit>5.8.2</version.junit>
+    <version.logback>1.2.10</version.logback>
+    <version.mockito>4.2.0</version.mockito>
+    <version.spring>5.3.14</version.spring>
     <version.unitils>3.4.6</version.unitils>
 
     <!-- Version of maven plugins -->


### PR DESCRIPTION
May we change the versioning schema to match the Hibernate base version (5.6) we compiled against?