### PR TITLE
Hibernate 6.2 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
     <profile>
       <id>hibernate-6.1</id>
       <properties>
-        <version.hibernate>6.1.6.Final</version.hibernate>
+        <version.hibernate>6.1.7.Final</version.hibernate>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -83,17 +83,17 @@
     <!-- Version of third libraries -->
     <!-- * Hibernate dependencies -->
     <!-- * Last Hibernate supported version  -->
-    <version.hibernate>6.1.6.Final</version.hibernate>
+    <version.hibernate>6.1.7.Final</version.hibernate>
 
     <!-- * For testing purpose -->
     <version.commons-lang3>3.12.0</version.commons-lang3>
     <version.dbunit>2.7.3</version.dbunit>
     <version.ehcache>2.6.11</version.ehcache>
     <version.h2>2.1.214</version.h2>
-    <version.junit>5.9.1</version.junit>
+    <version.junit>5.9.2</version.junit>
     <version.logback>1.4.5</version.logback>
-    <version.mockito>4.9.0</version.mockito>
-    <version.spring>6.0.2</version.spring>
+    <version.mockito>5.2.0</version.mockito>
+    <version.spring>6.0.6</version.spring>
     <version.unitils>3.4.6</version.unitils>
 
     <!-- Version of maven plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <!-- Version of third libraries -->
     <!-- * Hibernate dependencies -->
     <!-- * Last Hibernate supported version  -->
-    <version.hibernate>6.1.7.Final</version.hibernate>
+    <version.hibernate>6.2.0.CR3</version.hibernate>
 
     <!-- * For testing purpose -->
     <version.commons-lang3>3.12.0</version.commons-lang3>

--- a/src/main/java/com/javaetmoi/core/persistence/hibernate/LazyLoadingUtil.java
+++ b/src/main/java/com/javaetmoi/core/persistence/hibernate/LazyLoadingUtil.java
@@ -19,6 +19,7 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.collections.IdentitySet;
+import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.type.*;
@@ -195,6 +196,8 @@ public class LazyLoadingUtil {
         }
 
         var propertyTypes = descriptor.getPropertyTypes();
+        // Explicitly use Iterable here to be backward compatible to Hibernate 6.1.
+        Iterable<AttributeMapping> attributeMappings = descriptor.getAttributeMappings();
         for (var attributeMapping : descriptor.getAttributeMappings()) {
             var propertyValue = attributeMapping.getValue(target);
             var propertyType = propertyTypes[attributeMapping.getStateArrayPosition()];

--- a/src/main/java/com/javaetmoi/core/persistence/hibernate/LazyLoadingUtil.java
+++ b/src/main/java/com/javaetmoi/core/persistence/hibernate/LazyLoadingUtil.java
@@ -198,7 +198,7 @@ public class LazyLoadingUtil {
         var propertyTypes = descriptor.getPropertyTypes();
         // Explicitly use Iterable here to be backward compatible to Hibernate 6.1.
         Iterable<AttributeMapping> attributeMappings = descriptor.getAttributeMappings();
-        for (var attributeMapping : descriptor.getAttributeMappings()) {
+        for (var attributeMapping : attributeMappings) {
             var propertyValue = attributeMapping.getValue(target);
             var propertyType = propertyTypes[attributeMapping.getStateArrayPosition()];
             deepInflateProperty(mappingMetamodel, propertyValue, propertyType, recursiveGuard);

--- a/src/test/java/com/javaetmoi/core/persistence/hibernate/domain/Address.java
+++ b/src/test/java/com/javaetmoi/core/persistence/hibernate/domain/Address.java
@@ -36,7 +36,7 @@ public class Address {
     @ManyToOne(fetch = FetchType.LAZY)
     private Employee employee;
 
-    @OneToOne
+    @ManyToOne
     private Country  country;
 
     public Address() {


### PR DESCRIPTION
Hibernate 6.2 introduced `AttributeMappingsList` that is "just" an `Iterable<AttributeMapping>`. 
`EntityMappingType#getAttributeMappings()` now returns that instead of a `List<AttributeMapping>`.
The prior compiled for-each loop code in `LazyLoadingUtil#deepInflateEntity` expected a list and thus does not work with Hibernate 6.2.
Hopefully the reduction to `Iterable<AttributeMapping>` make the code run with Hibernate 6.1 and 6.2 (not released yet).