### PR TITLE
Hibernate 6.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <!-- Version of third libraries -->
     <!-- * Hibernate dependencies -->
     <!-- * Last Hibernate supported version  -->
-    <version.hibernate>6.2.1.Final</version.hibernate>
+    <version.hibernate>6.2.5.Final</version.hibernate>
 
     <!-- * For testing purpose -->
     <version.commons-lang3>3.12.0</version.commons-lang3>

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Download the jar though Maven:
 <dependency>
   <groupId>com.javaetmoi.core</groupId>
   <artifactId>javaetmoi-hibernate6-hydrate</artifactId>
-  <version>6.2.1</version>
+  <version>6.2.2</version>
 </dependency> 
 
 <!-- or Hibernate 5.2 and above support -->

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ A french article titled *Say goodbye to LazyInitializationException* : http://ja
 Download the jar though Maven:
 
 ```xml
-<!-- Either Hibernate 6.1 and above support -->
+<!-- Either Hibernate 6.1.6 and above support -->
 <dependency>
   <groupId>com.javaetmoi.core</groupId>
   <artifactId>javaetmoi-hibernate6-hydrate</artifactId>
@@ -61,7 +61,7 @@ Download the jar though Maven:
 </dependency> 
 ```
 
-Please note that we are not able to support Hibernate 6.0 due to bugs in it.
+Please note that we are not able to support Hibernate versions 6.0 up to 6.1.5 due to bugs in them.
 
 Hibernate Hydrate artefacts are available from [Maven Central](https://repo1.maven.org/maven2/com/javaetmoi/core/javaetmoi-hibernate6-hydrate/)
 

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ A french article titled *Say goodbye to LazyInitializationException* : http://ja
 Download the jar though Maven:
 
 ```xml
-<!-- Either Hibernate 6 and above support -->
+<!-- Either Hibernate 6.1 and above support -->
 <dependency>
   <groupId>com.javaetmoi.core</groupId>
   <artifactId>javaetmoi-hibernate6-hydrate</artifactId>
@@ -60,6 +60,8 @@ Download the jar though Maven:
   <version>2.2</version>
 </dependency> 
 ```
+
+Please note that we are not able to support Hibernate 6.0 due to bugs in it.
 
 Hibernate Hydrate artefacts are available from [Maven Central](https://repo1.maven.org/maven2/com/javaetmoi/core/javaetmoi-hibernate6-hydrate/)
 

--- a/src/main/java/com/javaetmoi/core/persistence/hibernate/LazyLoadingUtil.java
+++ b/src/main/java/com/javaetmoi/core/persistence/hibernate/LazyLoadingUtil.java
@@ -196,13 +196,12 @@ public class LazyLoadingUtil {
         }
 
         var propertyTypes = descriptor.getPropertyTypes();
-        // Explicitly use Iterable here to be backward compatible to Hibernate 6.1.
-        Iterable<AttributeMapping> attributeMappings = descriptor.getAttributeMappings();
-        for (var attributeMapping : attributeMappings) {
-            var propertyValue = attributeMapping.getValue(target);
+        var finalTarget = target;
+        descriptor.getAttributeMappings().forEach(attributeMapping -> {
+            var propertyValue = attributeMapping.getValue(finalTarget);
             var propertyType = propertyTypes[attributeMapping.getStateArrayPosition()];
             deepInflateProperty(mappingMetamodel, propertyValue, propertyType, recursiveGuard);
-        }
+        });
     }
 
     private static void deepInflateComponent(


### PR DESCRIPTION
Add compatibility for Hibernate 6.2.5. This contains just the minimal needed changes.