### PR TITLE
Fix detection of the class of the initial entity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
     <version.hibernate>6.3.0.Final</version.hibernate>
 
     <!-- * For testing purpose -->
+    <version.assertj>3.24.2</version.assertj>
     <version.commons-lang3>3.13.0</version.commons-lang3>
     <version.dbunit>2.7.3</version.dbunit>
     <version.h2>2.2.222</version.h2>
@@ -133,6 +134,12 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>${version.junit}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${version.assertj}</version>
       <scope>test</scope>
     </dependency>
     <!-- * Logger -->

--- a/src/test/java/com/javaetmoi/core/persistence/hibernate/AbstractTest.java
+++ b/src/test/java/com/javaetmoi/core/persistence/hibernate/AbstractTest.java
@@ -1,21 +1,27 @@
 package com.javaetmoi.core.persistence.hibernate;
 
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
+import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.stat.Statistics;
 import org.hibernate.testing.transaction.TransactionUtil;
 import org.hibernate.testing.transaction.TransactionUtil.JPATransactionFunction;
 import org.junit.jupiter.api.BeforeEach;
 
+import java.util.function.Consumer;
+
 import static com.javaetmoi.core.persistence.hibernate.JpaLazyLoadingUtil.deepHydrate;
 import static jakarta.persistence.Persistence.createEntityManagerFactory;
-import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AbstractTest {
 
-    private final EntityManagerFactory entityManagerFactory =
+    protected final EntityManagerFactory entityManagerFactory =
             createEntityManagerFactory("hibernate-hydrate");
+    protected final SessionFactory sessionFactory =
+            entityManagerFactory.unwrap(SessionFactory.class);
     private final DBUnitLoader dbUnitLoader =
             new DBUnitLoader((String) entityManagerFactory.getProperties().get("hibernate.connection.url"));
 
@@ -32,7 +38,7 @@ public class AbstractTest {
     //
 
     protected Statistics statistics() {
-        return entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        return sessionFactory.getStatistics();
     }
 
     protected <E> E findDeepHydratedEntity(Class<E> entityClass, long entityId) {
@@ -41,9 +47,27 @@ public class AbstractTest {
                         entityManager.find(entityClass, entityId)));
     }
 
+    protected <E> E findDeepHydratedEntityReference(Class<E> entityClass, long entityId) {
+        return doInJPA(entityManager -> {
+            var reference = entityManager.getReference(entityClass, entityId);
+            // Ensure that we got a proxy.
+            assertThat(reference)
+                    .isInstanceOf(HibernateProxy.class)
+                    .extracting(Object::getClass).isNotEqualTo(entityClass);
+            return deepHydrate(entityManager, reference);
+        });
+    }
+
     protected <E> E findEntity(Class<E> entityClass, long entityId) {
         return doInJPA(entityManager ->
                 entityManager.find(entityClass, entityId));
+    }
+
+    protected void doInJPAVoid(Consumer<EntityManager> action) {
+        doInJPA(entityManager -> {
+            action.accept(entityManager);
+            return null;
+        });
     }
 
     protected <R> R doInJPA(JPATransactionFunction<R> action) {

--- a/src/test/java/com/javaetmoi/core/persistence/hibernate/TestLazyLoadingUtil.java
+++ b/src/test/java/com/javaetmoi/core/persistence/hibernate/TestLazyLoadingUtil.java
@@ -18,6 +18,7 @@ import com.javaetmoi.core.persistence.hibernate.domain.Country;
 import com.javaetmoi.core.persistence.hibernate.domain.Employee;
 import com.javaetmoi.core.persistence.hibernate.domain.Project;
 import org.hibernate.LazyInitializationException;
+import org.hibernate.Session;
 import org.hibernate.collection.spi.PersistentMap;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.internal.util.collections.IdentitySet;
@@ -117,18 +118,18 @@ class TestLazyLoadingUtil extends AbstractTest {
     }
 
     /**
-     * Tests the method {@link LazyLoadingUtil#deepInflateInitialEntity(MappingMetamodel, Object, IdentitySet)}.
+     * Tests the method {@link LazyLoadingUtil#deepHydrate(Session, Object)}.
      */
     @Test
-    void deepInflateInitialEntity_nullEntity() {
+    void deepHydrate_nullEntity() {
         assertThat(LazyLoadingUtil.deepHydrate(sessionFactory, (Object) null)).isNull();
     }
 
     /**
-     * Tests the method {@link LazyLoadingUtil#deepInflateInitialEntity(MappingMetamodel, Object, IdentitySet)}.
+     * Tests the method {@link LazyLoadingUtil#deepHydrate(Session, Object)}.
      */
     @Test
-    void deepInflateInitialEntity_newEntity() {
+    void deepHydrate_newEntity() {
         // Test that we handle new entities correctly. Success if no exception.
         var deepHydratedNewEntity = LazyLoadingUtil.deepHydrate(sessionFactory, android);
 
@@ -136,10 +137,10 @@ class TestLazyLoadingUtil extends AbstractTest {
     }
 
     /**
-     * Tests the method {@link LazyLoadingUtil#deepInflateInitialEntity(MappingMetamodel, Object, IdentitySet)}.
+     * Tests the method {@link LazyLoadingUtil#deepHydrate(Session, Object)}.
      */
     @Test
-    void deepInflateInitialEntity_attachedEntity() {
+    void deepHydrate_attachedEntity() {
         // Test that we handle attached entities correctly. Success if no exception.
         var deepHydratedEntity = findDeepHydratedEntity(Address.class, paris.getId());
 
@@ -148,10 +149,10 @@ class TestLazyLoadingUtil extends AbstractTest {
     }
 
     /**
-     * Tests the method {@link LazyLoadingUtil#deepInflateInitialEntity(MappingMetamodel, Object, IdentitySet)}.
+     * Tests the method {@link LazyLoadingUtil#deepHydrate(Session, Object)}.
      */
     @Test
-    void deepInflateInitialEntity_attachedEntityProxy() {
+    void deepHydrate_attachedEntityProxy() {
         // Test that we handle attached entity proxies correctly. Success if no exception.
         var deepHydratedEntityProxy = findDeepHydratedEntityReference(Address.class, paris.getId());
 

--- a/src/test/java/com/javaetmoi/core/persistence/hibernate/TestLazyLoadingUtil.java
+++ b/src/test/java/com/javaetmoi/core/persistence/hibernate/TestLazyLoadingUtil.java
@@ -21,8 +21,6 @@ import org.hibernate.LazyInitializationException;
 import org.hibernate.Session;
 import org.hibernate.collection.spi.PersistentMap;
 import org.hibernate.collection.spi.PersistentCollection;
-import org.hibernate.internal.util.collections.IdentitySet;
-import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.proxy.HibernateProxy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -209,9 +207,9 @@ class TestLazyLoadingUtil extends AbstractTest {
 
         // - Generated SQL statements number
         assertEquals(8, statistics().getEntityLoadCount(),
-                "All 8 entities are loaded: france, james, tom, android, iphone, paris, la d�fense and lyon");
+                "All 8 entities are loaded: france, james, tom, android, iphone, paris, la defense and lyon");
         assertEquals(6, statistics().getCollectionFetchCount(),
-                "6 collections should be fetched: james' adresses, james' projects, iPhone members, tom's adresses, tom's projects, android members");
+                "6 collections should be fetched: james' addresses, james' projects, iPhone members, tom's addresses, tom's projects, android members");
     }
 
     /**

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -4,7 +4,7 @@
              version="2.2">
   <persistence-unit name="hibernate-hydrate">
     <properties>
-      <property name="hibernate.connection.url" value="jdbc:h2:~/hibernate-hydrate" />
+      <property name="hibernate.connection.url" value="jdbc:h2:mem:hibernate-hydrate;DB_CLOSE_DELAY=-1" />
       <property name="hibernate.connection.username" value="" />
       <property name="hibernate.transaction.jta.platform" value="org.hibernate.testing.jta.TestingJtaPlatformImpl" />
       <property name="hibernate.current_session_context_class" value="org.hibernate.context.internal.ThreadLocalSessionContext" />


### PR DESCRIPTION
If an entity is a Hibernate proxy, no entity descriptor could be found for the entity proxy's class before. I now use `Hibernate.getClass(entity)` to let Hibernate extract the class of the underlying entity.

Do you mind a release?